### PR TITLE
Avoid setting display block when an element is about to be shown again

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 module.exports = shim
 
-function shim(elem, value) {
+function shim (element, value) {
     if (value === undefined) {
-        return elem.style.display === "none"
+        return element.style.display === 'none'
     }
 
-    elem.style.display = value ? "none" : "block"
+    element.style.display = (value || null) && 'none'
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "browserify": "13.0.0",
     "domify": "1.4.0",
     "tape": "4.5.1",
+    "tape-css": "^1.0.2-beta",
     "tape-run": "2.1.3"
   },
   "licenses": [

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
-var test = require('tape')
+var tape = require('tape')
+var test = require('tape-css')(tape)
 var domify = require('domify')
 var hidden = require('./')
 
@@ -25,4 +26,21 @@ test('Sets an element\'s hiddenness', function(t) {
 	t.notOk(hidden(el))
 
 	t.end()
+})
+
+test('Get original display property after hiding/showing an element', {
+    dom: document.createElement('div'),
+    styles: 'div { display: table; }',
+}, function(t) {
+    var el = document.querySelector('div')
+
+    hidden(el, true)
+    t.ok(hidden(el))
+
+    hidden(el, false)
+
+    t.equal(getComputedStyle(el).getPropertyValue('display'), 'table')
+    t.notOk(hidden(el))
+
+    t.end()
 })


### PR DESCRIPTION
I have got this scenario. I had an element, originally with a `display: table` in css. If it was hidden after I applied a `hidden(el, true)`, I did not expect to get a `display: block` when I wanted it to be visible again.

What my code is doing, just remove the `display` property from the style attribute when you apply `hidden(el, false)`.

For me, it fits a bit better in the hidden philosophy. What do you think?